### PR TITLE
remove ezpickle args

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -287,9 +287,8 @@ class Wrapper(Env[WrapperObsType, WrapperActType]):
 
     @property
     def spec_stack(self) -> tuple[Union[EnvSpec, WrapperSpec]]:
-        assert hasattr(self, "_ezpickle_kwargs") and hasattr(self, "_ezpickle_args")
-        wrapper_spec = WrapperSpec(type(self).__name__, self.__module__ + ":" + type(self).__name__, self._ezpickle_args,
-                                   self._ezpickle_kwargs)
+        assert hasattr(self, "_ezpickle_kwargs")
+        wrapper_spec = WrapperSpec(type(self).__name__, self.__module__ + ":" + type(self).__name__, self._ezpickle_kwargs)
         return (wrapper_spec,) + self.env.spec_stack
 
     @classmethod

--- a/gymnasium/dataclasses.py
+++ b/gymnasium/dataclasses.py
@@ -13,5 +13,4 @@ class WrapperSpec:
 
     name: str
     entry_point: str
-    args: "list[Any]"
     kwargs: "list[Any]"

--- a/gymnasium/utils/ezpickle.py
+++ b/gymnasium/utils/ezpickle.py
@@ -19,17 +19,15 @@ class EzPickle:
 
     def __init__(self, *args, **kwargs):
         """Uses the ``args`` and ``kwargs`` from the object's constructor for pickling."""
-        self._ezpickle_args = args
         self._ezpickle_kwargs = kwargs
 
     def __getstate__(self):
         """Returns the object pickle state with args and kwargs."""
         return {
-            "_ezpickle_args": self._ezpickle_args,
             "_ezpickle_kwargs": self._ezpickle_kwargs,
         }
 
     def __setstate__(self, d):
         """Sets the object pickle state using d."""
-        out = type(self)(*d["_ezpickle_args"], **d["_ezpickle_kwargs"])
+        out = type(self)(**d["_ezpickle_kwargs"])
         self.__dict__.update(out.__dict__)

--- a/gymnasium/utils/serialize_spec_stack.py
+++ b/gymnasium/utils/serialize_spec_stack.py
@@ -57,22 +57,10 @@ def deserialise_spec_stack(
     for name, spec_json in stack_json.items():
         spec = json.loads(spec_json)
 
-        # convert lists back into tuples (args)
-        if name != "raw_env":  # EnvSpecs do not have args, only kwargs
-            for k, v in enumerate(
-                spec["args"]
-            ):  # json saves tuples as lists, so we need to convert them back (assumes depth <2, todo: recursify this)
-                if type(v) == list:
-                    for i, x in enumerate(v):
-                        if type(x) == list:
-                            spec["args"][k][i] = tuple(x)
-                    spec["args"][k] = tuple(v)
-            spec["args"] = tuple(spec["args"])
-
-        # convert lists back into tuples (kwargs)
+        # convert lists back into tuples - json saves tuples as lists, so we need to convert them back (assumes depth <2, todo: recursify this)
         for k, v in spec[
             "kwargs"
-        ].items():  # json saves tuples as lists, so we need to convert them back (assumes depth <2, todo: recursify this)
+        ].items():
             if type(v) == list:
                 for i, x in enumerate(v):
                     if type(x) == list:


### PR DESCRIPTION
- including ezpickle args is bad practice (less interpretability)
- current json pprint assumes no args
- current serialisation assumes no callables in args
- not 100% sure how easy it is to maintain order in serialisation/deserialisation
- they're never used anyway